### PR TITLE
Adding more parameters to output

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -17,8 +17,15 @@ type commitData struct {
 	After      string
 	Ref        string
 	UserName   string
+	Object_Kind string
 	Repository struct {
-		Url string
+		Url  string
+		Name string
+	}
+	Object_Attributes struct {
+		Source_Branch string
+		Target_Branch string
+		State         string
 	}
 }
 
@@ -45,6 +52,11 @@ func setGitData(form url.Values, g commitData) {
 	form.Set("END", g.After)
 	form.Set("REFNAME", g.Ref)
 	form.Set("GITURL", g.Repository.Url)
+	form.Set("REPOSITORY_NAME", g.Repository.Name)
+	form.Set("OBJECT_KIND", g.Object_Kind)
+	form.Set("SOURCE_BRANCH", g.Object_Attributes.Source_Branch)
+	form.Set("TARGET_BRANCH", g.Object_Attributes.Target_Branch)
+	form.Set("STATE", g.Object_Attributes.State)
 }
 
 func proxyToEndpoint(url string, form url.Values, w http.ResponseWriter) error {


### PR DESCRIPTION
These extra parameters should help to handle merge request processing in Jenkins.

Example when receiving a merge request:

```
END=&GITURL=git%40gitlab.com%3Aosandroribeiro%2Flalala.git&OBJECT_KIND=merge_request&REFNAME=&REPOSITORY_NAME=lalala&SOURCE_BRANCH=feature-1&START=&STATE=opened&TARGET_BRANCH=master&payload=%7B%22object_kind%22%3A%22merge_request%22%2C%22user%22%3A%7B%22name%22%3A%22Sandro+Ribeiro%22%2C%22username%22%3A%22osandroribeiro%22%2C%22avatar_url%22%3A%22https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F15fe82c9299f2eb0ff8ee0be9f3ad03c%3Fs%3D40%5Cu0026d%3Didenticon%22%7D%2C%22repository%22%3A%7B%22name%22%3A%22lalala%22%2C%22url%22%3A%22git%40gitlab.com%3Aosandroribeiro%2Flalala.git%22%2C%22description%22%3A%22%22%2C%22homepage%22%3A%22https%3A%2F%2Fgitlab.com%2Fosandroribeiro%2Flalala%22%7D%2C%22object_attributes%22%3A%7B%22id%22%3A166499%2C%22target_branch%22%3A%22master%22%2C%22source_branch%22%3A%22feature-1%22%2C%22source_project_id%22%3A494366%2C%22author_id%22%3A234635%2C%22assignee_id%22%3Anull%2C%22title%22%3A%22Feature+1%22%2C%22created_at%22%3A%222015-10-01+12%3A37%3A11+UTC%22%2C%22updated_at%22%3A%222015-10-01+12%3A37%3A11+UTC%22%2C%22milestone_id%22%3Anull%2C%22state%22%3A%22opened%22%2C%22merge_status%22%3A%22unchecked%22%2C%22target_project_id%22%3A494366%2C%22iid%22%3A8%2C%22description%22%3A%22%22%2C%22position%22%3A0%2C%22locked_at%22%3Anull%2C%22updated_by_id%22%3Anull%2C%22source%22%3A%7B%22name%22%3A%22lalala%22%2C%22ssh_url%22%3A%22git%40gitlab.com%3Aosandroribeiro%2Flalala.git%22%2C%22http_url%22%3A%22https%3A%2F%2Fgitlab.com%2Fosandroribeiro%2Flalala.git%22%2C%22web_url%22%3A%22https%3A%2F%2Fgitlab.com%2Fosandroribeiro%2Flalala%22%2C%22namespace%22%3A%22osandroribeiro%22%2C%22visibility_level%22%3A0%7D%2C%22target%22%3A%7B%22name%22%3A%22lalala%22%2C%22ssh_url%22%3A%22git%40gitlab.com%3Aosandroribeiro%2Flalala.git%22%2C%22http_url%22%3A%22https%3A%2F%2Fgitlab.com%2Fosandroribeiro%2Flalala.git%22%2C%22web_url%22%3A%22https%3A%2F%2Fgitlab.com%2Fosandroribeiro%2Flalala%22%2C%22namespace%22%3A%22osandroribeiro%22%2C%22visibility_level%22%3A0%7D%2C%22last_commit%22%3A%7B%22id%22%3A%22271cd8cac35b5afbdedea7eb59179a2035fbed3f%22%2C%22message%22%3A%22feature-1%3A+teste+mais+uma+tela%22%2C%22timestamp%22%3A%222015-09-28T14%3A20%3A55%2B00%3A00%22%2C%22url%22%3A%22https%3A%2F%2Fgitlab.com%2Fosandroribeiro%2Flalala%2Fcommit%2F271cd8cac35b5afbdedea7eb59179a2035fbed3f%22%2C%22author%22%3A%7B%22name%22%3A%22Sandro+Ribeiro%22%2C%22email%22%3A%22sandro.ribeiro%40adtsys.com.br%22%7D%7D%2C%22url%22%3A%22https%3A%2F%2Fgitlab.com%2Fosandroribeiro%2Flalala%2Fmerge_requests%2F8%22%2C%22action%22%3A%22open%22%7D%7D
```
